### PR TITLE
Add Token dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,14 +180,18 @@ import {I18nLoaderToken, HydrationStateToken} from 'fusion-plugin-i18n';
 import {FetchToken} from 'fusion-tokens';
 
 __NODE__ && app.register(I18nLoaderToken, I18nLoader);
-__BROWSER__ && app.register(HydrationStateToken, hydrationState);
 __BROWSER__ && app.register(FetchToken, fetch);
+
+// some-test.js
+__BROWSER__ && app.register(HydrationStateToken, hydrationState);
 ```
+
+##### Optional dependencies
 
 Name | Type | Default | Description
 -|-|-|-
 `I18nLoaderToken` | `{from: (ctx: Context) => ({locale: string, translations: Object<string, string>})}` | `createI18nLoader()` | A function that provides translations.  `ctx: {headers: {'accept-language': string}}` is a Koa context object.  Server-side only.
-`HydrationStateToken` | `{chunks: Array, translations: Object}` | `undefined` | Sets the hydrated state in the client.  Browser only.
+`HydrationStateToken` | `{chunks: Array, translations: Object}` | `undefined` | Sets the hydrated state in the client, and can be useful for testing purposes.  Browser only.
 `FetchToken` | `(url: string, options: Object) => Promise` | `window.fetch` | A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.  Browser-only.
 
 #### Factory

--- a/README.md
+++ b/README.md
@@ -176,23 +176,23 @@ Usage:
 #### Dependency registration
 
 ```js
-import I18n, {I18nToken, I18nLoaderToken} from 'fusion-plugin-i18n-react';
+import {I18nLoaderToken, HydrationStateToken} from 'fusion-plugin-i18n';
 import {FetchToken} from 'fusion-tokens';
 
-app.register(I18nToken, I18n);
-__NODE__
-  ? app.register(I18nLoaderToken, I18nLoader);
-  : app.register(FetchToken, fetch);
+__NODE__ && app.register(I18nLoaderToken, I18nLoader);
+__BROWSER__ && app.register(HydrationStateToken, hydrationState);
+__BROWSER__ && app.register(FetchToken, fetch);
 ```
 
-- `I18n` - the core I18n library
-- `I18nLoader: (ctx: Context) => ({locale: string, translations: Object<string, string>})` - A function that provides translations
-  - `ctx: FusionContext` - A [FusionJS context](https://github.com/fusionjs/fusion-core#context) object.
-- `fetch` - a [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation
+Name | Type | Default | Description
+-|-|-|-
+`I18nLoaderToken` | `{from: (ctx: Context) => ({locale: string, translations: Object<string, string>})}` | `createI18nLoader()` | A function that provides translations.  `ctx: {headers: {'accept-language': string}}` is a Koa context object.  Server-side only.
+`HydrationStateToken` | `{chunks: Array, translations: Object}` | `undefined` | Sets the hydrated state in the client.  Browser only.
+`FetchToken` | `(url: string, options: Object) => Promise` | `window.fetch` | A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.  Browser-only.
 
 #### Factory
 
-`const i18n = I18n(ctx)`
+`const i18n = I18n.from(ctx)`
 
 - `ctx: FusionContext` - Required. A [FusionJS context](https://github.com/fusionjs/fusion-core#context) object.
 


### PR DESCRIPTION
Fixes #81  | Rendered: [link](https://github.com/AlexMSmithCA/fusion-plugin-i18n-react/blob/e9f9e3a3246e6e4b52af18f407fe8d23c7361d93/README.md)

> #### Problem/Rationale
> 
> Documentation regarding Fusion API is out of date given recent changes to leverage new Dependency Injection architecture. 
> 
> #### Solution/Change/Deliverable
> 
> Update documentation