### PR TITLE
Improve typing for withTranslations HOC

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,29 +6,15 @@
  * @flow
  */
 
-import * as React from 'react';
-import {
+import I18n from './plugin';
+
+export {
   I18nToken,
   I18nLoaderToken,
   HydrationStateToken,
   createI18nLoader,
 } from 'fusion-plugin-i18n';
-
-import I18n from './plugin';
-import {withTranslations} from './with-translations';
-
-export default I18n;
-export {I18nToken, I18nLoaderToken, HydrationStateToken, createI18nLoader};
+export {withTranslations} from './with-translations';
 export {Translate} from './translate';
 
-type TranslatePropType = {
-  translate: (key: string, interpolations: Object) => string,
-};
-type WithTranslationsType<TProps> = (
-  translationKeys: Array<string>
-) => (
-  React.ComponentType<TProps>
-) => React.ComponentType<TProps | TranslatePropType>;
-
-const withTranslationsTyped: WithTranslationsType<*> = withTranslations;
-export {withTranslationsTyped as withTranslations};
+export default I18n;

--- a/src/with-translations.js
+++ b/src/with-translations.js
@@ -10,7 +10,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import type {Context} from 'fusion-core';
 
-type TranslateType = (key: string, interpolations?: {[string]: string | number}) => string;
+type TranslateType = (
+  key: string,
+  interpolations?: {[string]: string | number}
+) => string;
 
 /*
 The `withTranslations` HOC takes an array of translation keys as an argument,
@@ -26,15 +29,16 @@ export const withTranslations = (
 ) => {
   return <T: {}>(
     Component: React$ComponentType<T>
-  ): Class<React$Component<$Diff<T, {|translate?: TranslateType|}>, *>> => {
+  ): Class<React$Component<$Diff<T, {|translate?: TranslateType|}>>> => {
     class WithTranslations extends React.Component<T> {
       translate: TranslateType;
 
-      constructor(props: *, context: Context) {
+      constructor(props: T, context: Context) {
         super(props, context);
         const {i18n} = context;
         this.translate = i18n
-          ? (key: string, interpolations?: {[string]: string | number}) => i18n.translate(key, interpolations)
+          ? (key: string, interpolations?: {[string]: string | number}) =>
+              i18n.translate(key, interpolations)
           : (key: string) => key;
       }
 

--- a/src/with-translations.js
+++ b/src/with-translations.js
@@ -6,45 +6,49 @@
  * @flow
  */
 
-import React, {Component} from 'react';
-import type {ComponentType} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
+import type {Context} from 'fusion-core';
+
+type TranslateType = (key: string, interpolations?: {[string]: string | number}) => string;
 
 /*
 The `withTranslations` HOC takes an array of translation keys as an argument,
 but does not use it at runtime.
-
 However, these keys are captured by `babel-plugin-i18n` at compile-time by
 Fusion's compiler and the compiler uses generate a map of all translations
 in the app.
-
 The translation map is then exposed by `fusion-plugin-i18n/chunk-translation-map.js`
 */
-export const withTranslations = (/*translationKeys*/) => {
-  return (OriginalComponent: ComponentType<any>) => {
-    class WithTranslations extends Component<any> {
-      translateProp: any;
 
-      constructor(props: any, context: any) {
+export const withTranslations = (
+  translationKeys: string[] /*translationKeys*/
+) => {
+  return <T: {}>(
+    Component: React$ComponentType<T>
+  ): Class<React$Component<$Diff<T, {|translate?: TranslateType|}>, *>> => {
+    class WithTranslations extends React.Component<T> {
+      translate: TranslateType;
+
+      constructor(props: *, context: Context) {
         super(props, context);
         const {i18n} = context;
-        this.translateProp = i18n
-          ? (key, data) => i18n.translate(key, data)
-          : key => key;
+        this.translate = i18n
+          ? (key: string, interpolations?: {[string]: string | number}) => i18n.translate(key, interpolations)
+          : (key: string) => key;
       }
+
       render() {
-        const finalProps = Object.assign(
-          {translate: this.translateProp},
-          this.props
-        );
-        return React.createElement(OriginalComponent, finalProps);
+        return <Component {...this.props} translate={this.translate} />;
       }
     }
-    WithTranslations.contextTypes = OriginalComponent.contextTypes = {
-      i18n: PropTypes.object,
+
+    const displayName = Component.displayName || Component.name;
+    WithTranslations.displayName = `withTranslations(${displayName})`;
+    WithTranslations.contextTypes = {
+      i18n: PropTypes.object.isRequired,
     };
-    WithTranslations.displayName = `withTranslations(${OriginalComponent.displayName ||
-      OriginalComponent.name})`;
+
     return WithTranslations;
   };
 };


### PR DESCRIPTION
Currently using the `withTranslations` HOC results in typing being dropped. I was able to get this HOC component working with flow typing in my own repo but wanted to push it upstream.