### PR TITLE
Export passed through types for TranslationsObjectType and TranslateFuncType

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublish": "npm run transpile"
   },
   "dependencies": {
-    "fusion-plugin-i18n": "^1.2.2-0",
+    "fusion-plugin-i18n": "^1.2.2-1",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublish": "npm run transpile"
   },
   "dependencies": {
-    "fusion-plugin-i18n": "^1.2.1-0",
+    "fusion-plugin-i18n": "^1.2.2-0",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,13 @@ export {
   HydrationStateToken,
   createI18nLoader,
 } from 'fusion-plugin-i18n';
+export type {
+  I18nDepsType,
+  I18nServiceType,
+  TranslationsObjectType,
+  TranslateFuncType,
+} from 'fusion-plugin-i18n';
+
 export {withTranslations} from './with-translations';
 export {Translate} from './translate';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,10 +3321,10 @@ fusion-core@^1.10.1:
     ua-parser-js "^0.7.19"
     uuid "^3.3.2"
 
-fusion-plugin-i18n@^1.2.1-0:
-  version "1.2.1-0"
-  resolved "https://registry.yarnpkg.com/fusion-plugin-i18n/-/fusion-plugin-i18n-1.2.1-0.tgz#64c05c6caa60ed3557afbfa3062138c6f7c1f45e"
-  integrity sha512-vECtUXL2rDv8deqnR2//V7+2XozODR+96b5kjouEy+MCPOvH3MvaGrq10FA6hpZMYrXXeZ47hkJBBFY+Y96tGg==
+fusion-plugin-i18n@^1.2.2-0:
+  version "1.2.2-0"
+  resolved "https://registry.yarnpkg.com/fusion-plugin-i18n/-/fusion-plugin-i18n-1.2.2-0.tgz#0b11dfd9988ffb4551d5482ec2541fc512f048e3"
+  integrity sha512-RSP3kZ8VyVrOnQ9Uv7ACBqbSdccyBRgzmBST9yVZYo2y2SVHN0MqZSOYhxORSznvgHM49yBvIvBGiju+NS3wrA==
   dependencies:
     locale "^0.1.0"
     rollup "^0.67.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,10 +3321,10 @@ fusion-core@^1.10.1:
     ua-parser-js "^0.7.19"
     uuid "^3.3.2"
 
-fusion-plugin-i18n@^1.2.2-0:
-  version "1.2.2-0"
-  resolved "https://registry.yarnpkg.com/fusion-plugin-i18n/-/fusion-plugin-i18n-1.2.2-0.tgz#0b11dfd9988ffb4551d5482ec2541fc512f048e3"
-  integrity sha512-RSP3kZ8VyVrOnQ9Uv7ACBqbSdccyBRgzmBST9yVZYo2y2SVHN0MqZSOYhxORSznvgHM49yBvIvBGiju+NS3wrA==
+fusion-plugin-i18n@^1.2.2-1:
+  version "1.2.2-1"
+  resolved "https://registry.yarnpkg.com/fusion-plugin-i18n/-/fusion-plugin-i18n-1.2.2-1.tgz#c171daff506356c40e761195fb20691c9032d06f"
+  integrity sha512-sWwLinB3qE1dgFMNkW+zx0jaYGiygs2C08KpusvzKPJheidkWS3HuewLaPCoJodQryC9MgrnyVKShI5xYB6GHA==
   dependencies:
     locale "^0.1.0"
     rollup "^0.67.3"


### PR DESCRIPTION
Resolves [WPT-2853](https://jeng.uberinternal.com/browse/WPT-2853):

> The types defined and exported in `fusion-plugin-i18n` are not re-exported by `fusion-plugin-i18n-react`.
> See [fusion-plugin-i18n/src/index.js](https://github.com/fusionjs/fusion-plugin-i18n/blob/master/src/index.js) and [fusion-plugin-i18n-react/src/index.js](https://github.com/fusionjs/fusion-plugin-i18n-react/blob/master/src/index.js)
> This can cause problems where consumers that have `fusion-plugin-i18n-react` must also directly depend upon the non-React version in order to explicitly type `i18n` downstream.