### PR TITLE
Release v1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion-plugin-i18n-react",
-  "version": "1.2.5-0",
+  "version": "1.2.5",
   "description": "Adds I18n (Internationalization) support to a FusionJS app",
   "repository": "fusionjs/fusion-plugin-i18n-react",
   "files": [


### PR DESCRIPTION
- Export passed through types for TranslationsObjectType and TranslateFuncType ([#233](https://github.com/fusionjs/fusion-plugin-i18n-react/pull/233))